### PR TITLE
Update module.json compatibility fields

### DIFF
--- a/module.json
+++ b/module.json
@@ -28,8 +28,10 @@
     "scripts": [],
     "esmodules": ["./js/ferncombe.mjs"],
     "styles": ["./styles/ferncombe.css"],
-    "minimumCoreVersion": "11",
-    "compatibleCoreVersion": "11",
+    "compatibility": {
+        "minimum": "11",
+        "verified": "11"
+    },
     "packs": [
         {
             "name": "ferncombe",


### PR DESCRIPTION
Resolves the warning: `The module "ferncombe" is using the old flat core compatibility fields which are deprecated in favor of the new "compatibility" object`