### PR TITLE
Fix For Overriding Existing Sheet Classes

### DIFF
--- a/js/ferncombe.mjs
+++ b/js/ferncombe.mjs
@@ -50,7 +50,7 @@ Hooks.on("renderJournalPageSheet", (app, html, options) => {
 
   // Apply handwritten styles
   if ( doc.getFlag("ferncombe", "handwritten") ) html.addClass("handwritten");
-  
+
 });
 
 
@@ -59,13 +59,15 @@ Hooks.on("renderJournalPageSheet", (app, html, options) => {
 /* -------------------------------------------- */
 
 Hooks.on("preCreateJournalEntry", (doc, data, options, userId) => {
-  doc.data.update({
-    flags: {
-      core: {
-        sheetClass: "ferncombe.FerncombeJournalSheet"
+  if(!(data.flags && data.flags.core && data.flags.core.sheetClass)){
+    doc.data.update({
+      flags: {
+        core: {
+          sheetClass: "ferncombe.FerncombeJournalSheet"
+        }
       }
-    }
-  })
+    });
+  }
 });
 
 Hooks.on("preCreateJournalEntryPage", (doc, data, options, userId) => {


### PR DESCRIPTION
FIX: Updated the preCreateJournalEntry hook so that if the passed in data already contains a sheetClass to not update to the ferncombe sheetClass. If no sheetClass is set on the data then the ferncombe sheetClass will be set.

Details and insight for this pull request can be read in issue #2 